### PR TITLE
fix SECUSO apps link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Privacy Friendly Pedometer stores the user's step count per hour. The user c
 
 ## Motivation
 
-Privacy Friendly Pedometer belongs to the group of [Privacy Friendly Apps](https://www.secuso.informatik.tu-darmstadt.de/en/secuso-home/research/results/privacy-friendly-apps/) and has therefore been optimized with respect to user's privacy.
+Privacy Friendly Pedometer belongs to the group of [Privacy Friendly Apps](https://secuso.aifb.kit.edu/english/105.php) and has therefore been optimized with respect to user's privacy.
 
 ## Building
 


### PR DESCRIPTION
Fix a link that became broken when the SECUSO website moved over to KIT.